### PR TITLE
fix: rethrow the original error from `getTool`

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -29,10 +29,11 @@ export function parse(args) {
     .option('--verbose', 'Enables the verbose output', false)
     .description('Get an Arduino tool')
     .action(async (tool, version, options) => {
-      log('Getting tool', tool, version, JSON.stringify(options))
       if (options.verbose === true) {
         enable('gat:*')
       }
+      log('Getting tool', tool, version, JSON.stringify(options))
+
       try {
         const { toolPath } = await getTool({
           tool,
@@ -44,6 +45,9 @@ export function parse(args) {
       } catch (err) {
         log('Failed to download tool', err)
         console.log(err?.message || err)
+        if (err.code === 'EEXIST' && options.force !== true) {
+          console.log('Use --force to overwrite existing files')
+        }
       }
     })
 

--- a/src/cli.test.js
+++ b/src/cli.test.js
@@ -62,6 +62,25 @@ describe('cli', () => {
     await waitFor(() => expect(mockLog).toHaveBeenCalledWith('my error'))
   })
 
+  it('should prompt --force when errors with EEXIST', async () => {
+    jest
+      .mocked(getTool)
+      .mockRejectedValueOnce(
+        Object.assign(new Error('my error'), { code: 'EEXIST' })
+      )
+
+    parse(['node', 'script.js', 'get', 'arduino-cli', '1.1.1'])
+
+    await waitFor(() => expect(mockLog).toHaveBeenNthCalledWith(1, 'my error'))
+
+    await waitFor(() =>
+      expect(mockLog).toHaveBeenNthCalledWith(
+        2,
+        'Use --force to overwrite existing files'
+      )
+    )
+  })
+
   it('should print the reason as is when has no message', async () => {
     jest.mocked(getTool).mockRejectedValueOnce('just string')
 

--- a/src/get.test.js
+++ b/src/get.test.js
@@ -85,7 +85,8 @@ describe('get', () => {
   })
 
   it('should throw an error if download fails', async () => {
-    jest.mocked(download).mockRejectedValue(new Error('download error'))
+    const err = new Error('download error')
+    jest.mocked(download).mockRejectedValue(err)
 
     await expect(
       getTool({
@@ -93,9 +94,7 @@ describe('get', () => {
         version: mockVersion,
         destinationFolderPath: mockDestinationFolderPath,
       })
-    ).rejects.toThrow(
-      'Failed to download from https://downloads.arduino.cc/mock'
-    )
+    ).rejects.toThrow(err)
   })
 
   it('should overwrite the tool if force is true', async () => {
@@ -114,9 +113,8 @@ describe('get', () => {
   })
 
   it('should throw an error if tool already exists and force is false', async () => {
-    jest
-      .mocked(fs.open)
-      .mockRejectedValue(Object.assign(new Error(), { code: 'EEXIST' }))
+    const err = Object.assign(new Error(), { code: 'EEXIST' })
+    jest.mocked(fs.open).mockRejectedValue(err)
 
     await expect(
       getTool({
@@ -124,6 +122,6 @@ describe('get', () => {
         version: mockVersion,
         destinationFolderPath: mockDestinationFolderPath,
       })
-    ).rejects.toThrow('Tool already exists')
+    ).rejects.toThrow(err)
   })
 })


### PR DESCRIPTION
Fix rethrowing the original error from `getTool` to assist clients in handling `EEXIST`, ignoring it when `--force` is not set.