### PR TITLE
fix: correctly use version flag for Arduino lint in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ gat get <tool> <version> [options]
 - `-p, --platform <platform>`: Platform (default: current platform).
 - `-a, --arch <arch>`: Architecture (default: current architecture).
 - `-f, --force`: Force download to overwrite existing files (default: false).
-- `--ok-if-exists`: If the tool already exists and is executable, skip download and exit with code 0.
+- `--ok-if-exists`: If the tool already exists, skip download and exit with code 0.
 - `--verbose`: Enables verbose output (default: false).
 - `--silent`: Disables the progress bar (default: false).
 

--- a/src/cli.slow-test.js
+++ b/src/cli.slow-test.js
@@ -58,11 +58,8 @@ describe('cli', () => {
       tool: 'arduino-lint',
       version: '1.3.0',
       expectVersion: async (toolPath) => {
-        // The Arduino Lint requires the CLI to be in a library folder, for example
-        // _This will automatically detect the project type and check it against the relevant rules._
-        // https://arduino.github.io/arduino-lint/latest/#getting-started
-        const stdout = await execFile(toolPath, ['version'], true)
-        expect(stdout).toContain('PROJECT_PATH argument version does not exist')
+        const stdout = await execFile(toolPath, ['--version'], true)
+        expect(stdout).toContain('1.3.0')
       },
     },
   }


### PR DESCRIPTION
Ref: https://github.com/arduino/arduino-lint/issues/893